### PR TITLE
feat: Make `io` feature opt-in by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,7 @@ documentation = "https://docs.rs/nostd"
 memchr = { version = "2", default-features = false, optional = true }
 
 [features]
-default = [
-  "alloc",
-  "io",
-]
+default = ["alloc"]
 alloc = ["memchr?/alloc"]
 io = ["memchr"]
-std = [
-  "alloc",
-  "memchr?/std",
-]
+std = ["alloc"]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -14,18 +14,8 @@ mod impls;
 mod traits;
 mod util;
 
-#[cfg(not(feature = "std"))]
 pub use buffered::{BufReader, BufWriter, LineWriter};
-#[cfg(not(feature = "std"))]
 pub use cursor::Cursor;
-#[cfg(not(feature = "std"))]
 pub use error::{Error, ErrorKind, Result};
-#[cfg(not(feature = "std"))]
 pub use traits::{BufRead, Bytes, Chain, Read, Seek, SeekFrom, Take, Write};
-#[cfg(not(feature = "std"))]
 pub use util::copy;
-
-#[cfg(feature = "std")]
-pub use std::io::{
-    BufRead, Bytes, Chain, Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Take, Write,
-};


### PR DESCRIPTION
This PR makes the `io` feature opt-in by default, avoiding unnecessary dependency on the `memchr` crate when `io` functionality is not required.