### PR TITLE
docs: Exclude unstable `io` module from documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/conr2d/nostd.git"
 documentation = "https://docs.rs/nostd"
 
-[package.metadata.docs.rs]
-features = ["std"]
-
 [dependencies]
 memchr = { version = "2", default-features = false, optional = true }
 


### PR DESCRIPTION
This PR excludes the unstable `io` module from the documentation.

Currently, it is a re-export of `core2`, which has not been maintained for a long time. The module will need to be rewritten in the next version.