### PR TITLE
feat: Support hash collections by re-exporting hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/conr2d/nostd.git"
 documentation = "https://docs.rs/nostd"
 
 [dependencies]
+hashbrown = { version = "0.15", optional = true }
 memchr = { version = "2", default-features = false, optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,16 @@ pub mod ffi {
     pub mod c_str {}
 }
 
+#[cfg(feature = "alloc")]
+pub mod collections {
+    pub use alloc_::collections::*;
+
+    #[cfg(all(feature = "hashbrown", not(feature = "std")))]
+    pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};
+    #[cfg(feature = "std")]
+    pub use std::collections::{hash_map, hash_set, HashMap, HashSet};
+}
+
 #[cfg(all(feature = "io", not(feature = "std")))]
 pub mod io;
 #[cfg(feature = "std")]


### PR DESCRIPTION
This PR adds hash collection types by re-exporting `hashbrown` crate.