### PR TITLE
chore: Change alloc crate alias to __alloc

### DIFF
--- a/src/io/impls.rs
+++ b/src/io/impls.rs
@@ -161,7 +161,7 @@ impl Write for &mut [u8] {
 /// Write is implemented for `Vec<u8>` by appending to the vector.
 /// The vector will grow as needed.
 #[cfg(feature = "alloc")]
-impl Write for alloc_::vec::Vec<u8> {
+impl Write for __alloc::vec::Vec<u8> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         self.extend_from_slice(buf);

--- a/src/io/traits.rs
+++ b/src/io/traits.rs
@@ -11,7 +11,7 @@ use super::error::{Error, ErrorKind, Result};
 use core::{cmp, fmt, slice};
 
 #[cfg(feature = "alloc")]
-pub use alloc_::vec::Vec;
+pub use __alloc::vec::Vec;
 
 #[cfg(feature = "alloc")]
 struct Guard<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,14 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "alloc")]
-extern crate alloc as alloc_;
+extern crate alloc as __alloc;
 
 /// The nostd prelude
 ///
 /// This module is intended for users of nostd where linking to std is not possible or desirable.
 pub mod prelude {
     #[cfg(feature = "alloc")]
-    pub use alloc_::{
+    pub use __alloc::{
         borrow::ToOwned,
         boxed::Box,
         format,
@@ -28,14 +28,14 @@ pub mod prelude {
 }
 
 #[cfg(feature = "alloc")]
-pub use alloc_::*;
+pub use __alloc::*;
 pub use core::*;
 
 macro_rules! merge_exports {
     ($module:ident) => {
         pub mod $module {
             #[cfg(feature = "alloc")]
-            pub use alloc_::$module::*;
+            pub use __alloc::$module::*;
             #[allow(unused_imports)]
             pub use core::$module::*;
         }
@@ -52,7 +52,7 @@ merge_exports!(task);
 
 pub mod ffi {
     #[cfg(feature = "alloc")]
-    pub use alloc_::ffi::*;
+    pub use __alloc::ffi::*;
     #[allow(unused_imports)]
     pub use core::ffi::*;
     // Suppress ambiguous_glob_reexports
@@ -61,7 +61,7 @@ pub mod ffi {
 
 #[cfg(feature = "alloc")]
 pub mod collections {
-    pub use alloc_::collections::*;
+    pub use __alloc::collections::*;
 
     #[cfg(all(feature = "hashbrown", not(feature = "std")))]
     pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};


### PR DESCRIPTION
This PR updates the internal alias for `alloc` crate to resolve the naming conflict with the `alloc::alloc` module re-exported at the crate root.