### PR TITLE
feat: Re-export ffi::c_str for Rust 1.88 or later

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ features = ["hashbrown", "io"]
 [dependencies]
 hashbrown = { version = "0.15", optional = true }
 memchr = { version = "2", default-features = false, optional = true }
+rustversion = "1"
 
 [dev-dependencies]
 nostd = { path = ".", features = ["io"] }

--- a/src/io/impls.rs
+++ b/src/io/impls.rs
@@ -167,7 +167,7 @@ impl Write for &mut [u8] {
 /// Write is implemented for `Vec<u8>` by appending to the vector.
 /// The vector will grow as needed.
 #[cfg(feature = "alloc")]
-impl Write for __alloc::vec::Vec<u8> {
+impl Write for crate::vec::Vec<u8> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         self.extend_from_slice(buf);

--- a/src/io/traits.rs
+++ b/src/io/traits.rs
@@ -11,7 +11,7 @@ use super::error::{Error, ErrorKind, Result};
 use core::{cmp, fmt, slice};
 
 #[cfg(feature = "alloc")]
-pub use __alloc::vec::Vec;
+pub use crate::vec::Vec;
 
 #[cfg(feature = "alloc")]
 struct Guard<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,22 +80,22 @@ mod macros;
 pub use alloc_crate::*;
 pub use core::*;
 
-import!(alloc);
-import!(borrow);
-import!(fmt);
-import!(slice);
-import!(str);
-import!(sync);
-import!(task);
+export!(alloc);
+export!(borrow);
+export!(fmt);
+export!(slice);
+export!(str);
+export!(sync);
+export!(task);
 
 pub mod bstr {}
 
 pub mod ffi {
-    export!(ffi);
+    import!(ffi);
 
     pub mod c_str {
         #[rustversion::since(1.88)]
-        export!(ffi::c_str);
+        import!(ffi::c_str);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,7 @@ import!(str);
 import!(sync);
 import!(task);
 
-pub mod bstr {
-}
+pub mod bstr {}
 
 pub mod ffi {
     export!(ffi);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,36 +73,31 @@ pub mod prelude {
     };
 }
 
+#[macro_use]
+mod macros;
+
 #[cfg(feature = "alloc")]
 pub use alloc_crate::*;
 pub use core::*;
 
-macro_rules! merge_exports {
-    ($module:ident) => {
-        pub mod $module {
-            #[cfg(feature = "alloc")]
-            pub use alloc_crate::$module::*;
-            #[allow(unused_imports)]
-            pub use core::$module::*;
-        }
-    };
+import!(alloc);
+import!(borrow);
+import!(fmt);
+import!(slice);
+import!(str);
+import!(sync);
+import!(task);
+
+pub mod bstr {
 }
 
-merge_exports!(alloc);
-merge_exports!(borrow);
-merge_exports!(fmt);
-merge_exports!(slice);
-merge_exports!(str);
-merge_exports!(sync);
-merge_exports!(task);
-
 pub mod ffi {
-    #[cfg(feature = "alloc")]
-    pub use alloc_crate::ffi::*;
-    #[allow(unused_imports)]
-    pub use core::ffi::*;
-    // Suppress ambiguous_glob_reexports
-    pub mod c_str {}
+    export!(ffi);
+
+    pub mod c_str {
+        #[rustversion::since(1.88)]
+        export!(ffi::c_str);
+    }
 }
 
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,14 +56,14 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "alloc")]
-extern crate alloc as __alloc;
+extern crate alloc as alloc_crate;
 
 /// The nostd prelude
 ///
 /// This module is intended for users of nostd where linking to std is not possible or desirable.
 pub mod prelude {
     #[cfg(feature = "alloc")]
-    pub use __alloc::{
+    pub use alloc_crate::{
         borrow::ToOwned,
         boxed::Box,
         format,
@@ -74,14 +74,14 @@ pub mod prelude {
 }
 
 #[cfg(feature = "alloc")]
-pub use __alloc::*;
+pub use alloc_crate::*;
 pub use core::*;
 
 macro_rules! merge_exports {
     ($module:ident) => {
         pub mod $module {
             #[cfg(feature = "alloc")]
-            pub use __alloc::$module::*;
+            pub use alloc_crate::$module::*;
             #[allow(unused_imports)]
             pub use core::$module::*;
         }
@@ -98,7 +98,7 @@ merge_exports!(task);
 
 pub mod ffi {
     #[cfg(feature = "alloc")]
-    pub use __alloc::ffi::*;
+    pub use alloc_crate::ffi::*;
     #[allow(unused_imports)]
     pub use core::ffi::*;
     // Suppress ambiguous_glob_reexports
@@ -107,7 +107,7 @@ pub mod ffi {
 
 #[cfg(feature = "alloc")]
 pub mod collections {
-    pub use __alloc::collections::*;
+    pub use alloc_crate::collections::*;
 
     #[cfg(all(feature = "hashbrown", not(feature = "std")))]
     pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,31 @@
+// Copyright (C) Jeeyong Um <conr2d@proton.me>
+//               Jungyong Um <ian.jungyong.um@gmail.com>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_export]
+macro_rules! import {
+    ($mod:ident) => {
+        import!($mod, $mod);
+    };
+    ($mod:ident, $($path:ident)::*) => {
+        pub mod $mod {
+            export!($($path)*);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! export {
+    ($($path:ident)::*) => {
+        #[cfg(feature = "alloc")]
+        pub use alloc_crate::$($path::)**;
+        #[allow(unused_imports)]
+        pub use core::$($path::)**;
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,19 +9,19 @@
 // except according to those terms.
 
 #[macro_export]
-macro_rules! import {
+macro_rules! export {
     ($mod:ident) => {
-        import!($mod, $mod);
+        export!($mod, $mod);
     };
     ($mod:ident, $($path:ident)::*) => {
         pub mod $mod {
-            export!($($path)*);
+            import!($($path)*);
         }
     };
 }
 
 #[macro_export]
-macro_rules! export {
+macro_rules! import {
     ($($path:ident)::*) => {
         #[cfg(feature = "alloc")]
         pub use alloc_crate::$($path::)**;


### PR DESCRIPTION
This PR re-exports `ffi::c_str` symbols for Rust 1.88 or later and also includes the following changes:

- Clean up macros for re-exporting both `alloc` and `core` symbols
- Fix ambiguous glob reexports warnings for `bstr` module