### PR TITLE
fix: Resolve ambiguous glob reexports by wtf8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@ pub mod ffi {
     }
 }
 
+pub mod wtf8 {}
+
 #[cfg(feature = "alloc")]
 pub mod collections {
     pub use alloc_crate::collections::*;


### PR DESCRIPTION
This PR resolves the `ambiguous_glob_reexports` warnings emitted by the compiler due to `wtf8`.